### PR TITLE
神戸と滋賀を対応都市に追加

### DIFF
--- a/internal/weather/weather.go
+++ b/internal/weather/weather.go
@@ -24,6 +24,8 @@ func GetCityCoordinate(city string) (*types.CityCoordinate, error) {
 		"sendai":   {"仙台", 38.2682, 140.8694},
 		"hiroshima":{"広島", 34.3853, 132.4553},
 		"naha":     {"那覇", 26.2124, 127.6792},
+		"kobe":     {"神戸", 34.6901, 135.1956},
+		"shiga":    {"滋賀", 35.0044, 135.8686},
 	}
 	
 	if coord, exists := cities[city]; exists {


### PR DESCRIPTION
## Summary
- 神戸 (kobe) と滋賀 (shiga) をサポート都市として追加
- 各都市の正確な緯度・経度情報を設定
- 既存の機能に影響なく新しい都市での天気情報取得が可能

## Test plan
- [x] 神戸の天気情報取得テスト (`go run main.go -city=kobe`)
- [x] 滋賀の天気情報取得テスト (`go run main.go -city=shiga`)
- [x] 既存テストの実行確認 (`go test -v`)

🤖 Generated with [Claude Code](https://claude.ai/code)