### PR TITLE
不正な都市名エラーメッセージの改善とヘルプ機能の追加

### DIFF
--- a/internal/weather/weather.go
+++ b/internal/weather/weather.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"sort"
 	"strconv"
 	"time"
 	"runcast/internal/types"
@@ -11,28 +12,40 @@ import (
 
 const apiURL = "https://api.open-meteo.com/v1/jma"
 
+// Cities holds all supported cities
+var Cities = map[string]types.CityCoordinate{
+	"tokyo":    {"東京", 35.6762, 139.6503},
+	"osaka":    {"大阪", 34.6937, 135.5023},
+	"kyoto":    {"京都", 35.0116, 135.7681},
+	"yokohama": {"横浜", 35.4437, 139.6380},
+	"nagoya":   {"名古屋", 35.1815, 136.9066},
+	"sapporo":  {"札幌", 43.0642, 141.3469},
+	"fukuoka":  {"福岡", 33.5904, 130.4017},
+	"sendai":   {"仙台", 38.2682, 140.8694},
+	"hiroshima":{"広島", 34.3853, 132.4553},
+	"naha":     {"那覇", 26.2124, 127.6792},
+	"kobe":     {"神戸", 34.6901, 135.1956},
+	"shiga":    {"滋賀", 35.0044, 135.8686},
+}
+
+// GetSupportedCities returns a list of all supported city names
+func GetSupportedCities() []string {
+	cities := make([]string, 0, len(Cities))
+	for key := range Cities {
+		cities = append(cities, key)
+	}
+	sort.Strings(cities)
+	return cities
+}
+
 // GetCityCoordinate returns city coordinates by city name
 func GetCityCoordinate(city string) (*types.CityCoordinate, error) {
-	cities := map[string]types.CityCoordinate{
-		"tokyo":    {"東京", 35.6762, 139.6503},
-		"osaka":    {"大阪", 34.6937, 135.5023},
-		"kyoto":    {"京都", 35.0116, 135.7681},
-		"yokohama": {"横浜", 35.4437, 139.6380},
-		"nagoya":   {"名古屋", 35.1815, 136.9066},
-		"sapporo":  {"札幌", 43.0642, 141.3469},
-		"fukuoka":  {"福岡", 33.5904, 130.4017},
-		"sendai":   {"仙台", 38.2682, 140.8694},
-		"hiroshima":{"広島", 34.3853, 132.4553},
-		"naha":     {"那覇", 26.2124, 127.6792},
-		"kobe":     {"神戸", 34.6901, 135.1956},
-		"shiga":    {"滋賀", 35.0044, 135.8686},
-	}
-	
-	if coord, exists := cities[city]; exists {
+	if coord, exists := Cities[city]; exists {
 		return &coord, nil
 	}
 	
-	return nil, fmt.Errorf("都市が見つかりません: %s", city)
+	supportedCities := GetSupportedCities()
+	return nil, fmt.Errorf("都市が見つかりません: %s\n対応都市: %v", city, supportedCities)
 }
 
 // GetWeather fetches weather data from API

--- a/main.go
+++ b/main.go
@@ -11,12 +11,53 @@ import (
 	"runcast/internal/weather"
 )
 
+func showHelp() {
+	fmt.Println("🏃‍♂️ runcast - ランニング天気予報")
+	fmt.Println("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
+	fmt.Println("使用方法:")
+	fmt.Println("  runcast [オプション]")
+	fmt.Println()
+	fmt.Println("オプション:")
+	fmt.Println("  -city string")
+	fmt.Println("      都市名を指定 (デフォルト: tokyo)")
+	fmt.Println("  -time string")
+	fmt.Println("      時間帯を指定 (morning, noon, evening, night)")
+	fmt.Println("  -date string")
+	fmt.Println("      日付を指定 (today, tomorrow, day-after-tomorrow)")
+	fmt.Println("  -distance string")
+	fmt.Println("      目標距離を指定 (5k, 10k, half, full)")
+	fmt.Println("  -help")
+	fmt.Println("      このヘルプを表示")
+	fmt.Println()
+	fmt.Println("対応都市:")
+	supportedCities := weather.GetSupportedCities()
+	for i, city := range supportedCities {
+		if i > 0 {
+			fmt.Print(", ")
+		}
+		fmt.Print(city)
+	}
+	fmt.Println()
+	fmt.Println()
+	fmt.Println("例:")
+	fmt.Println("  runcast -city=osaka")
+	fmt.Println("  runcast -city=tokyo -time=morning")
+	fmt.Println("  runcast -city=kyoto -date=tomorrow -distance=10k")
+}
+
 func main() {
 	city := flag.String("city", "tokyo", "都市名を指定")
 	timeOfDay := flag.String("time", "", "時間帯を指定 (morning, noon, evening, night)")
 	dateSpec := flag.String("date", "", "日付を指定 (today, tomorrow, day-after-tomorrow)")
 	distanceFlag := flag.String("distance", "", "目標距離を指定 (5k, 10k, half, full)")
+	help := flag.Bool("help", false, "ヘルプを表示")
 	flag.Parse()
+
+	// Show help if requested
+	if *help {
+		showHelp()
+		return
+	}
 
 	// Distance category processing
 	var distanceCategory *types.DistanceCategory


### PR DESCRIPTION
## Summary
- 不正な都市名が指定された場合に、対応都市一覧を表示するよう改善
- -helpオプションで詳細な使用方法と対応都市を表示する機能を追加
- 都市一覧をアルファベット順にソート表示

## Test plan
- [x] 不正な都市名でのエラーメッセージ確認 (`go run main.go -city=invalid`)
- [x] ヘルプ機能の動作確認 (`go run main.go -help`)
- [x] 既存機能の動作確認 (`go run main.go -city=tokyo`)
- [x] 全テストの実行確認 (`go test -v`)

## Fixes
Fixes #13

🤖 Generated with [Claude Code](https://claude.ai/code)